### PR TITLE
Feat/cell render method

### DIFF
--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -36,17 +36,17 @@ class Cell
 		end
 	end
 
-	# def render(empty? = true)
-	# 	if fired_upon? == false
-	# 		"."
-	# 	elsif fired_upon? == true && empty? == true
-	# 		"M"
-	# 	elsif fired_upon? == true && empty? == false
-	# 	  "H"
-	# 	elsif fired_upon? == true && ship.sunk? == true
-	# 		"X"
-	# 	elsif fired_upon? == false && empty? == false
-	# 		"S"
-	# 	end
-	# end
+	def render(reveal_ship = false)
+		if fired_upon? == false && reveal_ship == true
+			"S"
+		elsif fired_upon? == true && empty? == true
+			"M"
+		elsif fired_upon? == true && ship.sunk? == true
+			"X"
+		elsif fired_upon? == true && empty? == false
+		  "H"
+		elsif fired_upon? == false
+			"."
+		end
+	end
 end

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -4,6 +4,7 @@ class Cell
 	def initialize(coordinate)
 		@coordinate = coordinate
 		@ship = ship
+		@fired_upon = 0
 	end
 
 	def empty?
@@ -19,13 +20,33 @@ class Cell
 	end
 
 	def fired_upon?
-		ship.number_of_hits > 0
-	end
-
-	def fire_upon
-		if empty? == false
-			ship.hit
+		if @fired_upon >= 1
+			true
+		elsif @fired_upon == 0
+			false
 		end
 	end
 
+	def fire_upon
+		if empty? == false && @fired_upon == 0
+			ship.hit
+			@fired_upon += 1
+		elsif empty? == true && @fired_upon == 0
+			@fired_upon += 1
+		end
+	end
+
+	# def render(empty? = true)
+	# 	if fired_upon? == false
+	# 		"."
+	# 	elsif fired_upon? == true && empty? == true
+	# 		"M"
+	# 	elsif fired_upon? == true && empty? == false
+	# 	  "H"
+	# 	elsif fired_upon? == true && ship.sunk? == true
+	# 		"X"
+	# 	elsif fired_upon? == false && empty? == false
+	# 		"S"
+	# 	end
+	# end
 end

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -4,6 +4,8 @@ require './lib/cell'
 RSpec.describe Cell do
 	cell = Cell.new("B4")
 	cruiser = Ship.new("Cruiser", 3)
+	cell_1 = Cell.new ("B4")
+	cell_2 = Cell.new ("C3")
 
 	it 'exists' do
 	 expect(cell).to be_instance_of(Cell)
@@ -30,7 +32,6 @@ RSpec.describe Cell do
 
 	it 'takes damage when fired upon' do
 		cell.place_ship(cruiser)
-
 		expect(cell.fired_upon?).to eq(false)
 
 		cell.fire_upon
@@ -38,4 +39,35 @@ RSpec.describe Cell do
 		expect(cell.ship.health).to eq(2)
 		expect(cell.fired_upon?).to eq(true)
 	end
+
+	it 'renders a cell that has not been fired upon' do
+
+		expect(cell_1.render).to eq(".")
+		expect(cell_2.render).to eq(".")
+
+	end
+
+	it 'renders a cell that shows a miss' do
+		cell_1.fire_upon
+		expect(cell_1.render).to eq("M")
+	end
+
+	it 'renders a cell that reveals a ship not fired upon' do
+		expect(cell_2.render(true)).to eq("S")
+	end
+
+	it 'renders a cell that shows a hit' do
+		cell_2.place_ship(cruiser)
+		cell_2.fire_upon
+		expect(cell_2.render).to eq("H")
+	end
+
+	it 'renders a cell that shows a ship has been sunk' do
+		cell_2.place_ship(cruiser)
+		cruiser.hit
+		cruiser.hit
+		expect(cruiser.sunk?).to eq(true)
+		expect(cell_2.render).to eq("X")
+	end
+
 end


### PR DESCRIPTION
This code adds the render method and also replaces the code inside the fire_upon and fired_upon? methods (and adds an instance variable to be used by both of those methods). Didn't rewrite the code for the sake of rewriting it – although it passed the tests for the previous interaction pattern, the fired_upon? method was throwing back a ton of errors when I tried to use it in the render method. The original methods were great for identifying what would happen if a ship was in the cell, but didn't really reflect any changes if there **wasn't** a ship in the cell. Hoping this rewrite satisfies both situations and if you feel like i should make any changes to clean up the code, feel free to tag where the changes should be made. 